### PR TITLE
feat: Add and configure deptry, mypy, and pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.11"
 description = "A molecular modeller and file parser."
 authors = ["Sam Ireland <mail@samireland.com>"]
 license = "MIT"
-readme = "README.rst"
+readme = "README.md"
 homepage = "https://atomium.samireland.com"
 repository = "https://github.com/SamIreland/atomium"
 keywords = ["chemistry", "bioinformatics", "proteins", "biochemistry", "molecules", "PDB", "MMCIF", "CIF", "MMTF"]
@@ -43,3 +43,27 @@ deptry = { version = "*", python = ">=3.7" }
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.deptry]
+extend_exclude = ["scripts"]
+ignore = ["DEP003"]
+
+[tool.mypy]
+[[tool.mypy.overrides]]
+module = [
+    "rmsd",
+    "scipy.spatial.distance",
+    "valerius",
+    "msgpack",
+    "paramiko",
+    "requests"
+]
+ignore_missing_imports = true
+
+[tool.pylint.messages_control]
+disable = [
+    "E1101",
+    "E1135",
+    "E1133",
+    "E1136",
+]


### PR DESCRIPTION
This commit adds and configures `deptry`, `mypy`, and `pylint` to the project to enable linting and static type checking.

- The dev dependencies `deptry`, `mypy`, and `pylint` were already present in `pyproject.toml`.
- The `README.rst` was renamed to `README.md` in `pyproject.toml` to allow `poetry` to install the project.
- `deptry` is configured to ignore the `scripts` directory and transitive dependency warnings.
- `mypy` is configured to ignore missing imports for packages that do not have stubs compatible with the project's supported Python versions.
- `pylint` is configured to ignore some errors that are caused by the dynamic nature of the code and would require significant refactoring to fix.